### PR TITLE
Fix array_key_exists is deprecated with objects PHP 7.4 - #20.

### DIFF
--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -180,13 +180,13 @@ class ArrayHelper
             $key = $lastKey;
         }
 
-        if (is_array($array) && array_key_exists((string)$key, $array)) {
+        if (is_array($array) && isset($array[$key])) {
             return $array[$key];
         }
 
         if (strpos($key, '.') !== false) {
             foreach (explode('.', $key) as $part) {
-                if (!array_key_exists($part, $array)) {
+                if (!isset($array[$part])) {
                     return $default;
                 }
                 $array = $array[$part];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #20 