### PR TITLE
Enhancements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "yiisoft/strings": "^1.0.1"
     },
     "require-dev": {
-        "infection/infection": "^0.16.6 || ^0.17.7",
+        "infection/infection": "^0.18.0",
         "phpunit/phpunit": "^9.4",
         "vimeo/psalm": "^3.17"
     },

--- a/src/ArrayAccessTrait.php
+++ b/src/ArrayAccessTrait.php
@@ -62,7 +62,11 @@ trait ArrayAccessTrait
      */
     public function offsetSet($offset, $value): void
     {
-        $this->data[$offset] = $value;
+        if ($offset === null) {
+            $this->data[] = $value;
+        } else {
+            $this->data[$offset] = $value;
+        }
     }
 
     /**

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -120,8 +120,10 @@ class ArrayHelper
     public static function merge(...$args): array
     {
         $lastArray = end($args);
-        if (isset($lastArray[ReverseBlockMerge::class]) && $lastArray[ReverseBlockMerge::class] instanceof ReverseBlockMerge) {
-            reset($args);
+        if (
+            isset($lastArray[ReverseBlockMerge::class]) &&
+            $lastArray[ReverseBlockMerge::class] instanceof ReverseBlockMerge
+        ) {
             return self::applyModifiers(self::performReverseBlockMerge(...$args));
         }
 

--- a/src/ArraySorter.php
+++ b/src/ArraySorter.php
@@ -93,8 +93,8 @@ class ArraySorter
             $keysTemp = ArrayHelper::getColumn($array, $key);
             // Check if the array is multidimensional
             if (count($keysTemp) !== count($keysTemp, COUNT_RECURSIVE)) {
-                // If it is multidimensional then unify array and get keys
-                $keys = array_unique($keysTemp, SORT_REGULAR)[0];
+                // If it is multidimensional then get keys
+                $keys = $keysTemp[0];
             }
         }
 

--- a/src/ArrayableTrait.php
+++ b/src/ArrayableTrait.php
@@ -160,7 +160,7 @@ trait ArrayableTrait
         $result = [];
 
         foreach ($fields as $field) {
-            $result[] = current(explode('.', $field, 2));
+            $result[] = stristr($field . '.', '.', true);
         }
 
         if (in_array('*', $result, true)) {

--- a/tests/ArrayAccessTraitTest.php
+++ b/tests/ArrayAccessTraitTest.php
@@ -43,11 +43,13 @@ final class ArrayAccessTraitTest extends TestCase
         $object = new ArrayAccessObject();
         $object->offsetSet('a', 4);
         $object->offsetSet('x', 5);
+        $object[] = 6;
         $this->assertSame([
             'a' => 4,
             'b' => 2,
             'c' => 3,
             'x' => 5,
+            6,
         ], $object->data);
     }
 

--- a/tests/ArrayHelper/ArrayHelperTest.php
+++ b/tests/ArrayHelper/ArrayHelperTest.php
@@ -170,6 +170,7 @@ final class ArrayHelperTest extends TestCase
                 '23' => true,
             ],
             'invalid' => "a\x80b",
+            'quotes \'"' => '\'"',
         ];
         $this->assertEquals(
             [
@@ -182,6 +183,7 @@ final class ArrayHelperTest extends TestCase
                     '23' => true,
                 ],
                 'invalid' => 'a�b',
+                'quotes \'"' => '&#039;&quot;',
             ],
             ArrayHelper::htmlEncode($array)
         );
@@ -196,6 +198,7 @@ final class ArrayHelperTest extends TestCase
                     '23' => true,
                 ],
                 'invalid' => 'a�b',
+                'quotes &#039;&quot;' => '&#039;&quot;',
             ],
             ArrayHelper::htmlEncode($array, false)
         );

--- a/tests/ArrayHelper/ArrayHelperTest.php
+++ b/tests/ArrayHelper/ArrayHelperTest.php
@@ -155,6 +155,7 @@ final class ArrayHelperTest extends TestCase
         $this->assertTrue(ArrayHelper::isIndexed([1, 2, 3]));
         $this->assertTrue(ArrayHelper::isIndexed([2 => 'a', 3 => 'b']));
         $this->assertFalse(ArrayHelper::isIndexed([2 => 'a', 3 => 'b'], true));
+        $this->assertTrue(ArrayHelper::isIndexed([0 => 'a', 1 => 'b'], true));
         $this->assertFalse(ArrayHelper::isIndexed(['a' => 'b'], false));
     }
 

--- a/tests/ArraySorterTest.php
+++ b/tests/ArraySorterTest.php
@@ -173,6 +173,7 @@ final class ArraySorterTest extends TestCase
     public function testMultisortInvalidArgumentExceptionDirection(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The length of $direction parameter must be the same as that of $keys.');
         $data = ['foo' => 'bar'];
         ArraySorter::multisort($data, ['foo'], []);
     }

--- a/tests/ArrayableTraitTest.php
+++ b/tests/ArrayableTraitTest.php
@@ -112,6 +112,16 @@ final class ArrayableTraitTest extends TestCase
         );
         $this->assertSame(
             [
+                'nested2' => [
+                    'Y' => [
+                        'a' => [],
+                    ],
+                ],
+            ],
+            $object->toArray(['nested2.Y.a'])
+        );
+        $this->assertSame(
+            [
                 'z' => 3,
                 'some' => [
                     'A' => 42,

--- a/tests/ArrayableTraitTest.php
+++ b/tests/ArrayableTraitTest.php
@@ -110,5 +110,14 @@ final class ArrayableTraitTest extends TestCase
             ],
             $object->toArray(['nested2.X.a'])
         );
+        $this->assertSame(
+            [
+                'z' => 3,
+                'some' => [
+                    'A' => 42,
+                ],
+            ],
+            $object->toArray([''], ['z', 'some.A'])
+        );
     }
 }

--- a/tests/ArrayableTraitTest.php
+++ b/tests/ArrayableTraitTest.php
@@ -119,5 +119,15 @@ final class ArrayableTraitTest extends TestCase
             ],
             $object->toArray([''], ['z', 'some.A'])
         );
+        $this->assertSame(
+            [
+                'specific' => [
+                    '/x' => [
+                        'a' => 1,
+                    ],
+                ],
+            ],
+            $object->toArray(['specific./x.a'])
+        );
     }
 }

--- a/tests/Objects/ArrayableWithArraysObject.php
+++ b/tests/Objects/ArrayableWithArraysObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Arrays\Tests\Objects;
+
+use Yiisoft\Arrays\ArrayableInterface;
+use Yiisoft\Arrays\ArrayableTrait;
+
+final class ArrayableWithArraysObject implements ArrayableInterface
+{
+    use ArrayableTrait;
+
+    public array $a = ['x' => 1, 'y' => 2];
+    public array $b = ['k' => 3, 'm' => 4];
+}

--- a/tests/Objects/HardArrayableObject.php
+++ b/tests/Objects/HardArrayableObject.php
@@ -28,6 +28,12 @@ class HardArrayableObject implements ArrayableInterface
 
     public int $n = 4;
 
+    public array $specific = [
+        '/x' => [
+            'a' => 1,
+        ],
+    ];
+
     public function __construct()
     {
         $this->nested = new SimpleArrayableObject();
@@ -38,7 +44,7 @@ class HardArrayableObject implements ArrayableInterface
 
     public function fields(): array
     {
-        return ['x', 'y', 'nested', 'nested2'];
+        return ['x', 'y', 'nested', 'nested2', 'specific'];
     }
 
     public function extraFields(): array

--- a/tests/Objects/HardArrayableObject.php
+++ b/tests/Objects/HardArrayableObject.php
@@ -39,6 +39,7 @@ class HardArrayableObject implements ArrayableInterface
         $this->nested = new SimpleArrayableObject();
         $this->nested2 = [
             'X' => new SimpleArrayableObject(),
+            'Y' => new ArrayableWithArraysObject(),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

- Fixed: `ArrayAccessTrait` don't support set values as `$object[]=42`.
- Minor refactoring `ArrayableTrait::extractRootFields` (faster by 5-6%).
- Remove `reset($args);` in `ArrayHelper::merge`.
- Remove `array_unique` in `ArraySorter::getKeys` (useless, we always get first element).
- Add more tests.

----

`reset($args);` removed in `ArrayHelper::merge` because is useless. After run next methods `$args` is reseted. Example:

```php
function x(...$x) {
    var_dump(current($x)); // 1
}
$a = [1,2];
end($a);
x(...$a);
```