### PR TITLE
Add working with closures to ArrayHelper::map()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "yiisoft/strings": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "roave/infection-static-analysis-plugin": "^1.5",
+        "phpunit/phpunit": "^9.5",
+        "roave/infection-static-analysis-plugin": "^1.6",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.2"
+        "vimeo/psalm": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -842,7 +842,7 @@ class ArrayHelper
     public static function map(array $array, $from, $to, $group = null): array
     {
         if ($group === null) {
-            if($from instanceof Closure || $to instanceof Closure) {
+            if ($from instanceof Closure || $to instanceof Closure) {
                 $result = [];
                 foreach ($array as $element) {
                     /** @var mixed */

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -842,6 +842,16 @@ class ArrayHelper
     public static function map(array $array, $from, $to, $group = null): array
     {
         if ($group === null) {
+            if($from instanceof Closure || $to instanceof Closure) {
+                $result = [];
+                foreach ($array as $element) {
+                    /** @var mixed */
+                    $result[static::getValue($element, $from)] = static::getValue($element, $to);
+                }
+
+                return $result;
+            }
+
             return array_column($array, $to, $from);
         }
 

--- a/tests/ArrayHelper/ArrayHelperTest.php
+++ b/tests/ArrayHelper/ArrayHelperTest.php
@@ -89,39 +89,6 @@ final class ArrayHelperTest extends TestCase
         $this->assertEquals(['abc', 'def'], $result);
     }
 
-    public function testMap(): void
-    {
-        $array = [
-            ['id' => '123', 'name' => 'aaa', 'class' => 'x'],
-            ['id' => '124', 'name' => 'bbb', 'class' => 'x'],
-            ['id' => '345', 'name' => 'ccc', 'class' => 'y'],
-        ];
-
-        $result = ArrayHelper::map($array, 'id', 'name');
-        $this->assertEquals(
-            [
-                '123' => 'aaa',
-                '124' => 'bbb',
-                '345' => 'ccc',
-            ],
-            $result
-        );
-
-        $result = ArrayHelper::map($array, 'id', 'name', 'class');
-        $this->assertEquals(
-            [
-                'x' => [
-                    '123' => 'aaa',
-                    '124' => 'bbb',
-                ],
-                'y' => [
-                    '345' => 'ccc',
-                ],
-            ],
-            $result
-        );
-    }
-
     public function testKeyExists(): void
     {
         $array = [

--- a/tests/ArrayHelper/MapTest.php
+++ b/tests/ArrayHelper/MapTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Arrays\Tests\ArrayHelper;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Arrays\ArrayHelper;
+
+/**
+ * @see MergeTest
+ */
+final class MapTest extends TestCase
+{
+    public function testWithoutGroup(): void
+    {
+        $array = [
+            ['from' => '1', 'to' => '1'],
+            ['from' => '2', 'to' => '2'],
+            ['from' => '2', 'to' => '2-last'],
+        ];
+
+        $this->assertSame(
+            [
+                '1' => '1',
+                '2' => '2-last',
+            ],
+            ArrayHelper::map($array, 'from', 'to')
+        );
+
+        $this->assertSame(
+            [
+                'key-1' => '1',
+                'key-2' => '2-last',
+            ],
+            ArrayHelper::map(
+                $array,
+                function ($row) {
+                    return "key-{$row['from']}";
+                },
+                'to'
+            )
+        );
+
+        $this->assertSame(
+            [
+                '1' => 'value-1',
+                '2' => 'value-2-last',
+            ],
+            ArrayHelper::map(
+                $array,
+                'from',
+                function ($row) {
+                    return "value-{$row['to']}";
+                }
+            )
+        );
+    }
+
+    public function testWithGroup(): void
+    {
+        $array = [
+            ['group' => '1', 'from' => '1', 'to' => '1.1'],
+            ['group' => '1', 'from' => '2', 'to' => '1.2'],
+            ['group' => '2', 'from' => '1', 'to' => '2.1'],
+            ['group' => '2', 'from' => '2', 'to' => '2.2'],
+            ['group' => '2', 'from' => '2', 'to' => '2.2-last'],
+        ];
+
+        $this->assertSame(
+            [
+                '1' => [
+                    '1' => '1.1',
+                    '2' => '1.2',
+                ],
+                '2' => [
+                    '1' => '2.1',
+                    '2' => '2.2-last',
+                ],
+            ],
+            ArrayHelper::map($array, 'from', 'to', 'group')
+        );
+
+        $this->assertSame(
+            [
+                '1' => [
+                    'key-1' => '1.1',
+                    'key-2' => '1.2',
+                ],
+                '2' => [
+                    'key-1' => '2.1',
+                    'key-2' => '2.2-last',
+                ],
+            ],
+            ArrayHelper::map(
+                $array,
+                function ($row) {
+                    return "key-{$row['from']}";
+                },
+                'to',
+                'group'
+            )
+        );
+
+        $this->assertSame(
+            [
+                '1' => [
+                    '1' => 'value-1.1',
+                    '2' => 'value-1.2',
+                ],
+                '2' => [
+                    '1' => 'value-2.1',
+                    '2' => 'value-2.2-last',
+                ],
+            ],
+            ArrayHelper::map(
+                $array,
+                'from',
+                function ($row) {
+                    return "value-{$row['to']}";
+                },
+                'group'
+            )
+        );
+
+        $this->assertSame(
+            [
+                'group-1' => [
+                    '1' => '1.1',
+                    '2' => '1.2',
+                ],
+                'group-2' => [
+                    '1' => '2.1',
+                    '2' => '2.2-last',
+                ],
+            ],
+            ArrayHelper::map(
+                $array,
+                'from',
+                'to',
+                function ($row) {
+                    return "group-{$row['group']}";
+                }
+            )
+        );
+    }
+}

--- a/tests/ArrayHelper/MapTest.php
+++ b/tests/ArrayHelper/MapTest.php
@@ -7,11 +7,41 @@ namespace Yiisoft\Arrays\Tests\ArrayHelper;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Arrays\ArrayHelper;
 
-/**
- * @see MergeTest
- */
 final class MapTest extends TestCase
 {
+    public function testBase(): void
+    {
+        $array = [
+            ['id' => '123', 'name' => 'aaa', 'class' => 'x'],
+            ['id' => '124', 'name' => 'bbb', 'class' => 'x'],
+            ['id' => '345', 'name' => 'ccc', 'class' => 'y'],
+        ];
+
+        $result = ArrayHelper::map($array, 'id', 'name');
+        $this->assertEquals(
+            [
+                '123' => 'aaa',
+                '124' => 'bbb',
+                '345' => 'ccc',
+            ],
+            $result
+        );
+
+        $result = ArrayHelper::map($array, 'id', 'name', 'class');
+        $this->assertEquals(
+            [
+                'x' => [
+                    '123' => 'aaa',
+                    '124' => 'bbb',
+                ],
+                'y' => [
+                    '345' => 'ccc',
+                ],
+            ],
+            $result
+        );
+    }
+
     public function testWithoutGroup(): void
     {
         $array = [


### PR DESCRIPTION
if `$group=null` and `$from` or `$to` is `Closure` then `array_column` throw errors 

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
