### PR TITLE
Remove support use Closure with return multiple keys for ArrayHelper::multisort + Importve test multisort Closure + Improve phpdoc + Update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.6",
+        "roave/infection-static-analysis-plugin": "^1.7",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.3"
+        "vimeo/psalm": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/ArrayAccessTrait.php
+++ b/src/ArrayAccessTrait.php
@@ -7,7 +7,8 @@ namespace Yiisoft\Arrays;
 use ArrayIterator;
 
 /**
- * ArrayAccessTrait provides the implementation for {@see \IteratorAggregate}, {@see \ArrayAccess} and {@see \Countable}.
+ * ArrayAccessTrait provides the implementation for {@see \IteratorAggregate}, {@see \ArrayAccess}
+ * and {@see \Countable}.
  *
  * Note that ArrayAccessTrait requires the class using it contain a property named `data` which should be an array.
  * The data will be exposed by ArrayAccessTrait to support accessing the class object like an array.

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -1160,7 +1160,7 @@ class ArrayHelper
      *
      * @return bool `true` if `$needle` was found in `$haystack`, `false` otherwise.
      *
-     * @see https://php.net/manual/en/function.in-array.php
+     * @link https://php.net/manual/en/function.in-array.php
      */
     public static function isIn($needle, iterable $haystack, bool $strict = false): bool
     {
@@ -1307,15 +1307,16 @@ class ArrayHelper
 
     /**
      * Returns the public member variables of an object.
-     * This method is provided such that we can get the public member variables of an object.
-     * It is different from `get_object_vars()` because the latter will return private
-     * and protected variables if it is called within the object itself.
      *
-     * @param object $object the object to be handled
+     * This method is provided such that we can get the public member variables of an object. It is different
+     * from {@see get_object_vars()} because the latter will return private and protected variables if it
+     * is called within the object itself.
      *
-     * @return array|null the public member variables of the object or null if not object given
+     * @param object $object The object to be handled.
      *
-     * @see https://www.php.net/manual/en/function.get-object-vars.php
+     * @return array|null The public member variables of the object or null if not object given.
+     *
+     * @link https://www.php.net/manual/en/function.get-object-vars.php
      */
     public static function getObjectVars(object $object): ?array
     {

--- a/src/ArraySorter.php
+++ b/src/ArraySorter.php
@@ -95,16 +95,6 @@ class ArraySorter
             return [];
         }
 
-        if ($key instanceof Closure) {
-            $keysTemp = ArrayHelper::getColumn($array, $key);
-            // Check if the array is multidimensional
-            if (count($keysTemp) !== count($keysTemp, COUNT_RECURSIVE)) {
-                // If it is multidimensional then get keys
-                /** @var array<array-key, string|Closure> */
-                $keys = $keysTemp[0];
-            }
-        }
-
         return $keys;
     }
 

--- a/src/ArrayableInterface.php
+++ b/src/ArrayableInterface.php
@@ -5,19 +5,22 @@ declare(strict_types=1);
 namespace Yiisoft\Arrays;
 
 /**
- * ArrayableInterface should be implemented by classes who want to support customizable representation of their instances.
+ * ArrayableInterface should be implemented by classes who want to support customizable representation
+ * of their instances.
  *
- * For example, if a class implements ArrayableInterface, by calling {@see ArrayableInterface::toArray()}, an instance of this class
- * can be turned into an array (including all its embedded objects) which can then be further transformed easily
- * into other formats, such as JSON, XML.
+ * For example, if a class implements ArrayableInterface, by calling {@see ArrayableInterface::toArray()},
+ * an instance of this class can be turned into an array (including all its embedded objects) which can
+ * then be further transformed easily into other formats, such as JSON, XML.
  *
- * The methods {@see ArrayableInterface::fields()} and {@see ArrayableInterface::extraFields()} allow the implementing classes to customize how and which of their data
- * should be formatted and put into the result of {@see ArrayableInterface::toArray()}.
+ * The methods {@see ArrayableInterface::fields()} and {@see ArrayableInterface::extraFields()} allow
+ * the implementing classes to customize how and which of their data should be formatted and put into
+ * the result of {@see ArrayableInterface::toArray()}.
  */
 interface ArrayableInterface
 {
     /**
-     * Returns the list of fields that should be returned by default by {@see toArray()} when no specific fields are specified.
+     * Returns the list of fields that should be returned by default by {@see toArray()} when no specific
+     * fields are specified.
      *
      * A field is a named element in the returned array by {@see toArray()}.
      *
@@ -59,7 +62,8 @@ interface ArrayableInterface
     public function fields(): array;
 
     /**
-     * Returns the list of additional fields that can be returned by {@see toArray()} in addition to those listed in {@see fields()}.
+     * Returns the list of additional fields that can be returned by {@see toArray()} in addition to those
+     * listed in {@see fields()}.
      *
      * This method is similar to {@see fields()} except that the list of fields declared
      * by this method are not returned by default by {@see toArray()}. Only when a field in the list
@@ -77,7 +81,8 @@ interface ArrayableInterface
      * Converts the object into an array.
      *
      * @param array $fields the fields that the output array should contain. Fields not specified
-     * in {@see fields()} will be ignored. If this parameter is empty, all fields as specified in {@see fields()} will be returned.
+     * in {@see fields()} will be ignored. If this parameter is empty, all fields as specified
+     * in {@see fields()} will be returned.
      * @param array $expand the additional fields that the output array should contain.
      * Fields not specified in {@see extraFields()} will be ignored. If this parameter is empty, no extra fields
      * will be returned.

--- a/src/ArrayableTrait.php
+++ b/src/ArrayableTrait.php
@@ -13,7 +13,8 @@ namespace Yiisoft\Arrays;
 trait ArrayableTrait
 {
     /**
-     * Returns the list of fields that should be returned by default by {@see ArrayableInterface::toArray()} when no specific fields are specified.
+     * Returns the list of fields that should be returned by default by {@see ArrayableInterface::toArray()}
+     * when no specific fields are specified.
      *
      * A field is a named element in the returned array by {@see ArrayableInterface::toArray()}.
      *
@@ -91,19 +92,22 @@ trait ArrayableTrait
     /**
      * Converts the model into an array.
      *
-     * This method will first identify which fields to be included in the resulting array by calling {@see resolveFields()}.
-     * It will then turn the model into an array with these fields. If `$recursive` is true,
-     * any embedded objects will also be converted into arrays.
-     * When embedded objects are {@see ArrayableInterface}, their respective nested fields will be extracted and passed to {@see ArrayableInterface::toArray()}.
+     * This method will first identify which fields to be included in the resulting array
+     * by calling {@see resolveFields()}. It will then turn the model into an array with these fields.
+     * If `$recursive` is true, any embedded objects will also be converted into arrays.
+     * When embedded objects are {@see ArrayableInterface}, their respective nested fields
+     * will be extracted and passed to {@see ArrayableInterface::toArray()}.
      *
      * @param array $fields the fields being requested.
      * If empty or if it contains '*', all fields as specified by {@see ArrayableInterface::fields()} will be returned.
      * Fields can be nested, separated with dots (.). e.g.: item.field.sub-field
-     * `$recursive` must be true for nested fields to be extracted. If `$recursive` is false, only the root fields will be extracted.
-     * @param array $expand the additional fields being requested for exporting. Only fields declared in {@see ArrayableInterface::extraFields()}
-     * will be considered.
+     * `$recursive` must be true for nested fields to be extracted. If `$recursive` is false, only the root fields
+     * will be extracted.
+     * @param array $expand the additional fields being requested for exporting. Only fields declared
+     * in {@see ArrayableInterface::extraFields()} will be considered.
      * Expand can also be nested, separated with dots (.). e.g.: item.expand1.expand2
-     * `$recursive` must be true for nested expands to be extracted. If `$recursive` is false, only the root expands will be extracted.
+     * `$recursive` must be true for nested expands to be extracted. If `$recursive` is false, only the root expands
+     * will be extracted.
      * @param bool $recursive whether to recursively return array representation of embedded objects.
      *
      * @return array the array representation of the object
@@ -200,8 +204,8 @@ trait ArrayableTrait
     /**
      * Determines which fields can be returned by {@see ArrayableInterface::toArray()}.
      * This method will first extract the root fields from the given fields.
-     * Then it will check the requested root fields against those declared in {@see ArrayableInterface::fields()} and {@see ArrayableInterface::extraFields()}
-     * to determine which fields can be returned.
+     * Then it will check the requested root fields against those declared in {@see ArrayableInterface::fields()}
+     * and {@see ArrayableInterface::extraFields()} to determine which fields can be returned.
      *
      * @param array $fields the fields being requested for exporting
      * @param array $expand the additional fields being requested for exporting

--- a/tests/ArraySorterTest.php
+++ b/tests/ArraySorterTest.php
@@ -59,13 +59,6 @@ final class ArraySorterTest extends TestCase
         $this->assertEquals(['name' => 'a', 'age' => 3], $array[1]);
         $this->assertEquals(['name' => 'b', 'age' => 2], $array[2]);
         $this->assertEquals(['name' => 'B', 'age' => 4], $array[3]);
-
-        ArraySorter::multisort($array, fn ($item) => ['age', 'name'], SORT_DESC);
-
-        $this->assertEquals(['name' => 'B', 'age' => 4], $array[0]);
-        $this->assertEquals(['name' => 'a', 'age' => 3], $array[1]);
-        $this->assertEquals(['name' => 'b', 'age' => 2], $array[2]);
-        $this->assertEquals(['name' => 'A', 'age' => 1], $array[3]);
     }
 
     public function testMultisortNestedObjects(): void

--- a/tests/ArraySorterTest.php
+++ b/tests/ArraySorterTest.php
@@ -131,17 +131,17 @@ final class ArraySorterTest extends TestCase
     public function testMultisortClosure(): void
     {
         $changelog = [
-            '- Enh #123: test1',
-            '- Bug #125: test2',
-            '- Bug #123: test2',
-            '- Enh: test3',
-            '- Bug: test4',
+            ['id' => 1, 'name' => '- Enh #123: test1'],
+            ['id' => 2, 'name' => '- Bug #125: test2'],
+            ['id' => 3, 'name' => '- Bug #123: test2'],
+            ['id' => 4, 'name' => '- Enh: test3'],
+            ['id' => 5, 'name' => '- Bug: test4'],
         ];
         $i = 0;
         ArraySorter::multisort(
             $changelog,
-            static function ($line) use (&$i) {
-                if (preg_match('/^- (Enh|Bug)( #\d+)?: .+$/', $line, $m)) {
+            static function (array $item) use (&$i) {
+                if (preg_match('/^- (Enh|Bug)( #\d+)?: .+$/', $item['name'], $m)) {
                     $o = ['Bug' => 'C', 'Enh' => 'D'];
                     return $o[$m[1]] . ' ' . (!empty($m[2]) ? $m[2] : 'AAAA' . $i++);
                 }
@@ -151,13 +151,13 @@ final class ArraySorterTest extends TestCase
             SORT_ASC,
             SORT_NATURAL
         );
-        $this->assertEquals(
+        $this->assertSame(
             [
-                '- Bug #123: test2',
-                '- Bug #125: test2',
-                '- Bug: test4',
-                '- Enh #123: test1',
-                '- Enh: test3',
+                ['id' => 3, 'name' => '- Bug #123: test2'],
+                ['id' => 2, 'name' => '- Bug #125: test2'],
+                ['id' => 5, 'name' => '- Bug: test4'],
+                ['id' => 1, 'name' => '- Enh #123: test1'],
+                ['id' => 4, 'name' => '- Enh: test3'],
             ],
             $changelog
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #60