### PR TITLE
Add getters' support (keys like "getMyProperty()") to `ArrayHelper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0 under development
 
+- Enh #122: Add getters' support (keys like "getMyProperty()") to `ArrayHelper` (@vjik) 
 - Enh #115: Raise required PHP version to `^8.0`, move union type hints from annotations
   to methods' signatures (@xepozz, @vjik)
 

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -243,6 +243,14 @@ final class ArrayHelper
         }
 
         if (is_object($array)) {
+            $key = (string) $key;
+
+            if (str_ends_with($key, '()')) {
+                $method = substr($key, 0, -2);
+                /** @psalm-suppress MixedMethodCall */
+                return $array->$method();
+            }
+
             try {
                 /** @psalm-suppress MixedPropertyFetch */
                 return $array::$$key;

--- a/tests/ArrayHelper/GetValueTest.php
+++ b/tests/ArrayHelper/GetValueTest.php
@@ -298,4 +298,16 @@ final class GetValueTest extends TestCase
 
         $this->assertSame(['c' => 'value'], $result);
     }
+
+    public function testGetters(): void
+    {
+        $object = new class() {
+            public function getValue(): int
+            {
+                return 7;
+            }
+        };
+
+        $this->assertSame(7, ArrayHelper::getValue($object, 'getValue()'));
+    }
 }

--- a/tests/ArrayHelper/GetValueTest.php
+++ b/tests/ArrayHelper/GetValueTest.php
@@ -301,7 +301,7 @@ final class GetValueTest extends TestCase
 
     public function testGetters(): void
     {
-        $object = new class() {
+        $object = new class () {
             public function getValue(): int
             {
                 return 7;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #90 