### PR TITLE
Remove `null` from return type of `ArrayHelper::getObjectVars()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New #139: Add `ArrayHelper::parametrizedMerge()` method that allows to merge two or more arrays recursively with
   specified depth (@vjik)
+- Enh #140: Remove `null` from return type of `ArrayHelper::getObjectVars()` method (@Tigrov) 
 
 ## 3.0.0 January 12, 2023
 

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -1321,11 +1321,11 @@ final class ArrayHelper
      *
      * @param object $object The object to be handled.
      *
-     * @return array|null The public member variables of the object or null if not object given.
+     * @return array The public member variables of the object.
      *
      * @link https://www.php.net/manual/en/function.get-object-vars.php
      */
-    public static function getObjectVars(object $object): ?array
+    public static function getObjectVars(object $object): array
     {
         return get_object_vars($object);
     }


### PR DESCRIPTION
`get_object_vars()` always returns `array` value

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
