### PR TITLE
Fix  `ArrayHelper::getValue()` and  `ArrayHelper::keyExists()` when key is empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `ArrayAccessTrait` (@vjik)
 - Bug #165: Explicitly mark nullable parameters (@vjik)
 - Enh #165: Raise the minimum PHP version to 8.1 (@vjik)
+- Bug #166: `ArrayHelper::getValue()` returns default value on empty array key (@vjik) 
 
 ## 3.1.0 April 04, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bug #165: Explicitly mark nullable parameters (@vjik)
 - Enh #165: Raise the minimum PHP version to 8.1 (@vjik)
 - Bug #166: `ArrayHelper::getValue()` returns default value on empty array key (@vjik) 
+- Bug #166: `ArrayHelper::keyExists()` returns false on empty array key (@vjik) 
 
 ## 3.1.0 April 04, 2024
 

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -214,6 +214,9 @@ final class ArrayHelper
         }
 
         if (is_array($key)) {
+            if (empty($key)) {
+                return $default;
+            }
             /** @psalm-var array<mixed,string|int> $key */
             $lastKey = array_pop($key);
             foreach ($key as $keyPart) {

--- a/src/ArrayHelper.php
+++ b/src/ArrayHelper.php
@@ -943,6 +943,10 @@ final class ArrayHelper
     public static function keyExists(array $array, array|float|int|string $key, bool $caseSensitive = true): bool
     {
         if (is_array($key)) {
+            if (empty($key)) {
+                return false;
+            }
+
             if (count($key) === 1) {
                 return self::rootKeyExists($array, end($key), $caseSensitive);
             }

--- a/tests/ArrayHelper/GetValueTest.php
+++ b/tests/ArrayHelper/GetValueTest.php
@@ -75,6 +75,8 @@ final class GetValueTest extends TestCase
             [['version', '1.0.name'], 'defaultValue', 'defaultValue'],
             [['post', 'author.name'], 'defaultValue', 'defaultValue'],
             ['42.7', 500],
+            [[], null, null],
+            [[], 'test', 'test'],
         ]);
     }
 

--- a/tests/ArrayHelper/KeyAndPathExistsTest.php
+++ b/tests/ArrayHelper/KeyAndPathExistsTest.php
@@ -65,6 +65,7 @@ final class KeyAndPathExistsTest extends TestCase
             [false, ['version', '1.0.name']],
             [false, ['post', 'author.name']],
             [true, '42.7'],
+            [false, []],
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
